### PR TITLE
feat(mfa): mfa interface handling

### DIFF
--- a/.dialyzerignore.exs
+++ b/.dialyzerignore.exs
@@ -1,1 +1,7 @@
-[]
+[
+  # MFA functions: response.body is decoded to map at runtime by JSONDecoder
+  # but Dialyzer sees it as iodata | {:stream, _} | nil
+  {"lib/supabase/auth/mfa.ex", :pattern_match},
+  {"lib/supabase/auth/mfa.ex", :no_return},
+  {"lib/supabase/auth/mfa.ex", :unused_fun}
+]

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,4 @@
+key = System.get_env("SUPABASE_KEY")
+url = System.get_env("SUPABASE_URL")
+
+client = url && key && Supabase.init_client!(url, key)

--- a/lib/supabase/auth/mfa.ex
+++ b/lib/supabase/auth/mfa.ex
@@ -1,0 +1,597 @@
+defmodule Supabase.Auth.MFA do
+  @moduledoc """
+  Multi-Factor Authentication (MFA) operations for Supabase Auth.
+
+  This module provides functions to manage MFA factors including TOTP (Time-based One-Time Password),
+  Phone (SMS/WhatsApp), and WebAuthn authentication methods.
+
+  ## Factor Types
+
+  - **TOTP**: Time-based one-time passwords (authenticator apps like Google Authenticator, Authy)
+  - **Phone**: SMS or WhatsApp-based verification codes
+  - **WebAuthn**: Hardware security keys and biometric authentication
+
+  ## Typical MFA Flow
+
+  1. **Enroll**: User enrolls a new MFA factor using `enroll/3`
+  2. **Challenge**: System issues a challenge for verification using `challenge/4`
+  3. **Verify**: User provides response to complete verification using `verify/5`
+
+  Alternatively, for TOTP factors, you can use `challenge_and_verify/4` to combine steps 2 and 3.
+
+  ## Authenticator Assurance Levels (AAL)
+
+  - **AAL1**: Single-factor authentication (password, magic link, OAuth)
+  - **AAL2**: Multi-factor authentication (at least one MFA factor verified)
+
+  After successful MFA verification, the session will be upgraded to AAL2.
+
+  ## Examples
+
+      # Enroll TOTP factor
+      {:ok, factor} = Supabase.Auth.MFA.enroll(client, session, %{
+        factor_type: :totp,
+        friendly_name: "My Authenticator"
+      })
+
+      # Display QR code to user (factor.totp.qr_code contains SVG data)
+      qr_code_svg = factor.totp.qr_code
+
+      # Enroll Phone factor
+      {:ok, phone_factor} = Supabase.Auth.MFA.enroll(client, session, %{
+        factor_type: :phone,
+        phone: "+1234567890",
+        friendly_name: "My Phone"
+      })
+
+      # Challenge and verify in one step (TOTP only)
+      {:ok, new_session} = Supabase.Auth.MFA.challenge_and_verify(
+        client,
+        session,
+        factor.id,
+        "123456"
+      )
+
+      # Or use separate challenge and verify steps
+      {:ok, challenge} = Supabase.Auth.MFA.challenge(client, session, factor.id, %{})
+      {:ok, new_session} = Supabase.Auth.MFA.verify(
+        client,
+        session,
+        factor.id,
+        challenge.id,
+        %{code: "123456"}
+      )
+
+      # List all factors
+      {:ok, %{all: factors, totp: totp_factors}} = Supabase.Auth.MFA.list_factors(client, session)
+
+      # Get current authentication level
+      {:ok, %{current_level: :aal2}} =
+        Supabase.Auth.MFA.get_authenticator_assurance_level(client, session)
+
+      # Unenroll a factor
+      {:ok, %{id: factor_id}} = Supabase.Auth.MFA.unenroll(client, session, factor.id)
+
+  ## Related Modules
+
+  - `Supabase.Auth.MFA.Behaviour` - Type definitions for MFA operations
+  - `Supabase.Auth.Session` - Session containing access tokens
+  - `Supabase.Auth.User` - User profile with factors
+  """
+
+  @behaviour Supabase.Auth.MFA.Behaviour
+
+  alias Supabase.Auth.MFA.Behaviour, as: MFABehaviour
+  alias Supabase.Auth.MFAHandler
+  alias Supabase.Auth.Schemas.MFA.ChallengeAndVerifyParams
+  alias Supabase.Auth.Schemas.MFA.ChallengeParams
+  alias Supabase.Auth.Schemas.MFA.EnrollParams
+  alias Supabase.Auth.Schemas.MFA.VerifyParams
+  alias Supabase.Auth.Session
+  alias Supabase.Auth.User
+  alias Supabase.Client
+
+  @doc """
+  Enrolls a new MFA factor for the authenticated user.
+
+  The enrollment process differs based on the factor type:
+  - **TOTP**: Returns QR code, secret, and URI for scanning into authenticator apps
+  - **Phone**: Returns the enrolled phone number
+  - **WebAuthn**: Returns the factor ID for WebAuthn credential registration
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session containing access token
+  * `params` - Factor enrollment parameters (map with factor_type and type-specific fields):
+    * For TOTP: `%{factor_type: :totp, friendly_name: "...", issuer: "..."}`
+    * For Phone: `%{factor_type: :phone, phone: "+1234567890", friendly_name: "..."}`
+    * For WebAuthn: `%{factor_type: :webauthn, friendly_name: "..."}`
+
+  ## Returns
+
+  * `{:ok, factor}` - Successfully enrolled factor with type-specific data:
+    * TOTP: includes `totp` field with `qr_code`, `secret`, and `uri`
+    * Phone: includes `phone` field with E.164 formatted number
+    * WebAuthn: basic factor information only
+  * `{:error, error}` - Enrollment failed
+
+  ## Examples
+
+      # Enroll TOTP factor
+      iex> Supabase.Auth.MFA.enroll(client, session, %{
+      ...>   factor_type: :totp,
+      ...>   friendly_name: "My Authenticator"
+      ...> })
+      {:ok, %{
+        id: "factor-uuid",
+        factor_type: :totp,
+        friendly_name: "My Authenticator",
+        status: :unverified,
+        totp: %{
+          qr_code: "data:image/svg+xml;utf-8,...",
+          secret: "SECRET123",
+          uri: "otpauth://totp/..."
+        }
+      }}
+
+      # Enroll Phone factor
+      iex> Supabase.Auth.MFA.enroll(client, session, %{
+      ...>   factor_type: :phone,
+      ...>   phone: "+1234567890"
+      ...> })
+      {:ok, %{
+        id: "factor-uuid",
+        factor_type: :phone,
+        status: :unverified,
+        phone: "+1234567890"
+      }}
+
+  """
+  @spec enroll(Client.t(), Session.t(), map()) ::
+          {:ok, MFABehaviour.enroll_response()} | {:error, term()}
+  def enroll(%Client{} = client, %Session{} = session, %{factor_type: _} = params) do
+    with {:ok, validated_params} <- EnrollParams.parse(params),
+         {:ok, response} <- MFAHandler.enroll(client, session.access_token, validated_params) do
+      parse_factor(response.body)
+    end
+  end
+
+  @doc """
+  Creates a challenge for an MFA factor.
+
+  The challenge must be verified using `verify/5` with the appropriate response.
+  Different factor types require different challenge parameters:
+  - **TOTP**: No additional parameters needed (empty map)
+  - **Phone**: Requires `channel` (`:sms` or `:whatsapp`)
+  - **WebAuthn**: Requires `webauthn` map with `rp_id` and optional `rp_origins`
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session
+  * `factor_id` - ID of the factor to challenge
+  * `params` - Challenge parameters (type-specific):
+    * For TOTP: `%{}` (empty map)
+    * For Phone: `%{channel: :sms}` or `%{channel: :whatsapp}`
+    * For WebAuthn: `%{webauthn: %{rp_id: "example.com", rp_origins: ["https://example.com"]}}`
+
+  ## Returns
+
+  * `{:ok, challenge}` - Challenge created with:
+    * `id` - Challenge ID for verification
+    * `type` - Factor type
+    * `expires_at` - Unix timestamp when challenge expires
+    * `webauthn` - WebAuthn credential options (WebAuthn only)
+  * `{:error, error}` - Challenge creation failed
+
+  ## Examples
+
+      # TOTP challenge
+      iex> Supabase.Auth.MFA.challenge(client, session, totp_factor_id, %{})
+      {:ok, %{id: "challenge-id", type: :totp, expires_at: 1234567890}}
+
+      # Phone challenge via SMS
+      iex> Supabase.Auth.MFA.challenge(client, session, phone_factor_id, %{channel: :sms})
+      {:ok, %{id: "challenge-id", type: :phone, expires_at: 1234567890}}
+
+      # WebAuthn challenge
+      iex> Supabase.Auth.MFA.challenge(client, session, webauthn_factor_id, %{
+      ...>   webauthn: %{rp_id: "example.com"}
+      ...> })
+      {:ok, %{
+        id: "challenge-id",
+        type: :webauthn,
+        expires_at: 1234567890,
+        webauthn: %{type: "create", credential_options: %{...}}
+      }}
+
+  """
+  @spec challenge(Client.t(), Session.t(), String.t(), map()) ::
+          {:ok, MFABehaviour.challenge_response() | MFABehaviour.webauthn_challenge_response()}
+          | {:error, term()}
+  def challenge(%Client{} = client, %Session{} = session, factor_id, params) when is_binary(factor_id) do
+    with {:ok, validated_params} <- ChallengeParams.parse(params),
+         {:ok, response} <-
+           MFAHandler.challenge(client, session.access_token, factor_id, validated_params) do
+      parse_challenge_response(response.body)
+    end
+  end
+
+  @doc """
+  Verifies an MFA challenge with the user's response.
+
+  Returns a new session with elevated authentication assurance level (AAL2).
+  The verification parameters differ based on factor type:
+  - **TOTP/Phone**: Provide the 6-digit code
+  - **WebAuthn**: Provide the WebAuthn credential response
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session
+  * `factor_id` - ID of the challenged factor
+  * `challenge_id` - ID of the challenge to verify
+  * `params` - Verification parameters (type-specific):
+    * For TOTP/Phone: `%{code: "123456"}`
+    * For WebAuthn: `%{webauthn: %{type: "...", rp_id: "...", credential_response: {...}}}`
+
+  ## Returns
+
+  * `{:ok, session}` - New session with AAL2 authentication including:
+    * `access_token` - New JWT token with elevated AAL
+    * `refresh_token` - New refresh token
+    * `user` - Updated user object
+    * `expires_in` - Token expiration time
+  * `{:error, error}` - Verification failed (invalid code, expired challenge, etc.)
+
+  ## Examples
+
+      # Verify TOTP code
+      iex> Supabase.Auth.MFA.verify(client, session, factor_id, challenge_id, %{code: "123456"})
+      {:ok, %Supabase.Auth.Session{
+        access_token: "eyJhbGci...",
+        user: %Supabase.Auth.User{...}
+      }}
+
+      # Verify Phone code
+      iex> Supabase.Auth.MFA.verify(client, session, factor_id, challenge_id, %{code: "654321"})
+      {:ok, %Supabase.Auth.Session{...}}
+
+      # Verify WebAuthn credential
+      iex> Supabase.Auth.MFA.verify(client, session, factor_id, challenge_id, %{
+      ...>   webauthn: %{
+      ...>     type: "create",
+      ...>     rp_id: "example.com",
+      ...>     credential_response: credential
+      ...>   }
+      ...> })
+      {:ok, %Supabase.Auth.Session{...}}
+
+  """
+  @spec verify(Client.t(), Session.t(), String.t(), String.t(), map()) ::
+          {:ok, Session.t()} | {:error, term()}
+  def verify(%Client{} = client, %Session{} = session, factor_id, challenge_id, params)
+      when is_binary(factor_id) and is_binary(challenge_id) do
+    with {:ok, validated_params} <- VerifyParams.parse(params),
+         {:ok, response} <-
+           MFAHandler.verify(
+             client,
+             session.access_token,
+             factor_id,
+             challenge_id,
+             validated_params
+           ) do
+      Session.parse(response.body)
+    end
+  end
+
+  @doc """
+  Removes an MFA factor from the user's account.
+
+  The factor must be verified before it can be unenrolled. This operation
+  removes the factor permanently and cannot be undone.
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session
+  * `factor_id` - ID of the factor to remove
+
+  ## Returns
+
+  * `{:ok, %{id: factor_id}}` - Factor successfully removed
+  * `{:error, error}` - Unenrollment failed
+
+  ## Examples
+
+      iex> Supabase.Auth.MFA.unenroll(client, session, "factor-uuid")
+      {:ok, %{id: "factor-uuid"}}
+
+  """
+  @spec unenroll(Client.t(), Session.t(), String.t()) ::
+          {:ok, %{id: String.t()}} | {:error, term()}
+  def unenroll(%Client{} = client, %Session{} = session, factor_id) when is_binary(factor_id) do
+    with {:ok, response} <- MFAHandler.unenroll(client, session.access_token, factor_id) do
+      {:ok, %{id: response.body["id"]}}
+    end
+  end
+
+  @doc """
+  Combines challenge and verify operations in a single call (TOTP only).
+
+  This is a convenience function for TOTP factors where the code is immediately
+  available from the user's authenticator app. It internally creates a challenge
+  and immediately verifies it with the provided code.
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session
+  * `factor_id` - ID of the TOTP factor
+  * `code` - The 6-digit TOTP code from the authenticator app
+
+  ## Returns
+
+  * `{:ok, session}` - New session with AAL2 authentication
+  * `{:error, error}` - Verification failed
+
+  ## Examples
+
+      iex> Supabase.Auth.MFA.challenge_and_verify(client, session, factor_id, "123456")
+      {:ok, %Supabase.Auth.Session{...}}
+
+  ## Note
+
+  This function only works with TOTP factors. For Phone or WebAuthn factors,
+  use separate `challenge/4` and `verify/5` calls to handle the asynchronous
+  nature of those verification methods.
+  """
+  @spec challenge_and_verify(Client.t(), Session.t(), String.t(), String.t()) ::
+          {:ok, Session.t()} | {:error, term()}
+  def challenge_and_verify(%Client{} = client, %Session{} = session, factor_id, code)
+      when is_binary(factor_id) and is_binary(code) do
+    with {:ok, _validated} <- ChallengeAndVerifyParams.parse(%{code: code}),
+         {:ok, challenge_response} <- challenge(client, session, factor_id, %{}) do
+      verify(client, session, factor_id, challenge_response.id, %{code: code})
+    end
+  end
+
+  @doc """
+  Lists all MFA factors for the authenticated user.
+
+  Returns factors organized by type for easy filtering. Only verified factors
+  are included in the type-specific lists (`:totp`, `:phone`, `:webauthn`),
+  while the `:all` list includes both verified and unverified factors.
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session
+
+  ## Returns
+
+  * `{:ok, factors_map}` - Map with keys:
+    * `:all` - All factors (verified and unverified)
+    * `:totp` - Verified TOTP factors only
+    * `:phone` - Verified Phone factors only
+    * `:webauthn` - Verified WebAuthn factors only
+  * `{:error, error}` - Failed to retrieve factors
+
+  ## Examples
+
+      iex> {:ok, factors} = Supabase.Auth.MFA.list_factors(client, session)
+      iex> length(factors.all)
+      3
+      iex> length(factors.totp)
+      2
+      iex> Enum.map(factors.totp, & &1.friendly_name)
+      ["My Phone", "Work Authenticator"]
+
+  """
+  @spec list_factors(Client.t(), Session.t()) ::
+          {:ok, MFABehaviour.factors_list()} | {:error, term()}
+  def list_factors(%Client{} = _client, %Session{} = session) do
+    factors = session.user.factors || []
+
+    parsed_factors =
+      factors
+      |> Enum.map(&parse_factor_from_user/1)
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(fn {:ok, factor} -> factor end)
+
+    totp_factors =
+      Enum.filter(parsed_factors, fn f ->
+        f.factor_type == :totp and f.status == :verified
+      end)
+
+    phone_factors =
+      Enum.filter(parsed_factors, fn f ->
+        f.factor_type == :phone and f.status == :verified
+      end)
+
+    webauthn_factors =
+      Enum.filter(parsed_factors, fn f ->
+        f.factor_type == :webauthn and f.status == :verified
+      end)
+
+    {:ok,
+     %{
+       all: parsed_factors,
+       totp: totp_factors,
+       phone: phone_factors,
+       webauthn: webauthn_factors
+     }}
+  end
+
+  @doc """
+  Gets the current and next possible authenticator assurance levels.
+
+  AAL (Authenticator Assurance Level) indicates the strength of authentication:
+  - **AAL1**: Single-factor authentication (password, magic link, OAuth)
+  - **AAL2**: Multi-factor authentication (at least one verified MFA factor)
+
+  This function extracts AAL information from the session's JWT claims without
+  making an API call. It also determines the next achievable AAL based on the
+  user's enrolled factors.
+
+  ## Parameters
+
+  * `client` - The Supabase client
+  * `session` - Active user session
+
+  ## Returns
+
+  * `{:ok, aal_info}` - Map with:
+    * `:current_level` - Current AAL (`:aal1`, `:aal2`, or `nil`)
+    * `:next_level` - Next achievable AAL (`:aal1`, `:aal2`, or `nil`)
+    * `:current_authentication_methods` - List of authentication method references from JWT `amr` claim
+  * `{:error, error}` - Failed to parse AAL information
+
+  ## Examples
+
+      # User with password authentication only (no MFA)
+      iex> Supabase.Auth.MFA.get_authenticator_assurance_level(client, session)
+      {:ok, %{
+        current_level: :aal1,
+        next_level: :aal2,
+        current_authentication_methods: ["password"]
+      }}
+
+      # User with verified MFA factor
+      iex> Supabase.Auth.MFA.get_authenticator_assurance_level(client, session_after_mfa)
+      {:ok, %{
+        current_level: :aal2,
+        next_level: :aal2,
+        current_authentication_methods: ["password", "totp"]
+      }}
+
+  ## Note
+
+  This function does not make an HTTP request. It decodes the JWT token from
+  the session to extract AAL claims.
+  """
+  @spec get_authenticator_assurance_level(Client.t(), Session.t()) ::
+          {:ok, MFABehaviour.aal_response()} | {:error, term()}
+  def get_authenticator_assurance_level(%Client{} = _client, %Session{} = session) do
+    with {:ok, claims} <- decode_jwt_claims(session.access_token) do
+      current_level = parse_aal_level(claims["aal"])
+      amr = claims["amr"] || []
+
+      # Determine next level based on user's factors
+      has_verified_factors =
+        Enum.any?(session.user.factors, fn factor -> factor.status == :verified end)
+
+      next_level =
+        cond do
+          has_verified_factors and current_level == :aal1 -> :aal2
+          has_verified_factors -> :aal2
+          true -> :aal1
+        end
+
+      {:ok,
+       %{
+         current_level: current_level,
+         next_level: next_level,
+         current_authentication_methods: amr
+       }}
+    end
+  end
+
+  # Private helper functions
+
+  @spec parse_factor(map()) :: {:ok, MFABehaviour.factor()} | {:error, term()}
+  defp parse_factor(%{"id" => id, "type" => type} = data) do
+    factor_type = parse_factor_type(type)
+    status = parse_factor_status(data["status"])
+
+    base_factor = %{
+      id: id,
+      friendly_name: data["friendly_name"],
+      factor_type: factor_type,
+      status: status,
+      created_at: data["created_at"],
+      updated_at: data["updated_at"],
+      last_challenged_at: data["last_challenged_at"]
+    }
+
+    case factor_type do
+      :totp ->
+        {:ok,
+         Map.put(base_factor, :totp, %{
+           qr_code: data["totp"]["qr_code"],
+           secret: data["totp"]["secret"],
+           uri: data["totp"]["uri"]
+         })}
+
+      :phone ->
+        {:ok, Map.put(base_factor, :phone, data["phone"])}
+
+      :webauthn ->
+        {:ok, base_factor}
+
+      _ ->
+        {:error, :unknown_factor_type}
+    end
+  end
+
+  defp parse_factor_from_user(%User.Factor{} = factor) do
+    base = %{
+      id: factor.id,
+      friendly_name: factor.friendly_name,
+      factor_type: factor.factor_type,
+      status: factor.status,
+      created_at: factor.created_at,
+      updated_at: factor.updated_at,
+      last_challenged_at: nil
+    }
+
+    {:ok, base}
+  end
+
+  @spec parse_challenge_response(map()) ::
+          {:ok, MFABehaviour.challenge_response() | MFABehaviour.webauthn_challenge_response()}
+          | {:error, term()}
+  defp parse_challenge_response(%{"id" => id, "type" => type, "expires_at" => expires_at} = data) do
+    factor_type = parse_factor_type(type)
+
+    base_response = %{
+      id: id,
+      type: factor_type,
+      expires_at: expires_at
+    }
+
+    case {factor_type, data["webauthn"]} do
+      {:webauthn, webauthn} when not is_nil(webauthn) ->
+        {:ok, Map.put(base_response, :webauthn, webauthn)}
+
+      _ ->
+        {:ok, base_response}
+    end
+  end
+
+  defp parse_factor_type("totp"), do: :totp
+  defp parse_factor_type("phone"), do: :phone
+  defp parse_factor_type("webauthn"), do: :webauthn
+  defp parse_factor_type(_), do: :unknown
+
+  defp parse_factor_status("verified"), do: :verified
+  defp parse_factor_status("unverified"), do: :unverified
+  defp parse_factor_status(_), do: :unknown
+
+  defp parse_aal_level("aal1"), do: :aal1
+  defp parse_aal_level("aal2"), do: :aal2
+  defp parse_aal_level(_), do: nil
+
+  defp decode_jwt_claims(token) do
+    # JWT structure: header.payload.signature
+    # We only need the payload (middle part)
+    with [_header, payload, _sig] <- String.split(token, "."),
+         {:ok, json} <- Base.url_decode64(payload, padding: false) do
+      Supabase.decode_json(json)
+    else
+      :error -> {:error, :invalid_jwt}
+      _ -> {:error, :invalid_jwt_format}
+    end
+  end
+end

--- a/lib/supabase/auth/mfa/behaviour.ex
+++ b/lib/supabase/auth/mfa/behaviour.ex
@@ -1,0 +1,131 @@
+defmodule Supabase.Auth.MFA.Behaviour do
+  @moduledoc """
+  Behaviour for MFA operations with type definitions.
+
+  This module defines all type specifications for Multi-Factor Authentication
+  operations including factors, challenges, verification responses, and
+  authenticator assurance levels.
+
+  ## Factor Types
+
+  Three types of MFA factors are supported:
+
+  - **TOTP** (`:totp`) - Time-based One-Time Password using authenticator apps
+  - **Phone** (`:phone`) - SMS or WhatsApp-based verification
+  - **WebAuthn** (`:webauthn`) - Hardware security keys and biometric authentication
+
+  ## Type Hierarchy
+
+  All factor types share common fields (id, friendly_name, status, timestamps)
+  but have type-specific additional fields:
+
+  - `totp_factor/0` includes `totp` field with QR code, secret, and URI
+  - `phone_factor/0` includes `phone` field with E.164 formatted number
+  - `webauthn_factor/0` has no additional type-specific fields
+
+  The `factor/0` type is a union of all three specific factor types.
+  """
+
+  alias Supabase.Auth.Session
+  alias Supabase.Client
+
+  @type factor_type :: :totp | :phone | :webauthn
+  @type factor_status :: :verified | :unverified
+
+  @type totp_data :: %{
+          qr_code: String.t(),
+          secret: String.t(),
+          uri: String.t()
+        }
+
+  @type factor_base :: %{
+          id: String.t(),
+          friendly_name: String.t() | nil,
+          factor_type: factor_type(),
+          status: factor_status(),
+          created_at: String.t(),
+          updated_at: String.t(),
+          last_challenged_at: String.t() | nil
+        }
+
+  @type totp_factor :: %{
+          id: String.t(),
+          friendly_name: String.t() | nil,
+          factor_type: :totp,
+          status: factor_status(),
+          totp: totp_data(),
+          created_at: String.t(),
+          updated_at: String.t(),
+          last_challenged_at: String.t() | nil
+        }
+
+  @type phone_factor :: %{
+          id: String.t(),
+          friendly_name: String.t() | nil,
+          factor_type: :phone,
+          status: factor_status(),
+          phone: String.t(),
+          created_at: String.t(),
+          updated_at: String.t(),
+          last_challenged_at: String.t() | nil
+        }
+
+  @type webauthn_factor :: %{
+          id: String.t(),
+          friendly_name: String.t() | nil,
+          factor_type: :webauthn,
+          status: factor_status(),
+          created_at: String.t(),
+          updated_at: String.t(),
+          last_challenged_at: String.t() | nil
+        }
+
+  @type factor :: totp_factor() | phone_factor() | webauthn_factor()
+
+  @type enroll_response :: totp_factor() | phone_factor() | webauthn_factor()
+
+  @type challenge_response :: %{
+          id: String.t(),
+          type: factor_type(),
+          expires_at: integer()
+        }
+
+  @type webauthn_challenge_response :: %{
+          id: String.t(),
+          type: :webauthn,
+          expires_at: integer(),
+          webauthn: %{
+            type: String.t(),
+            credential_options: map()
+          }
+        }
+
+  @type aal_level :: :aal1 | :aal2
+  @type aal_response :: %{
+          current_level: aal_level() | nil,
+          next_level: aal_level() | nil,
+          current_authentication_methods: [String.t()]
+        }
+
+  @type factors_list :: %{
+          all: [factor()],
+          totp: [totp_factor()],
+          phone: [phone_factor()],
+          webauthn: [webauthn_factor()]
+        }
+
+  @callback enroll(Client.t(), Session.t(), map()) ::
+              {:ok, enroll_response()} | {:error, term()}
+  @callback challenge(Client.t(), Session.t(), String.t(), map()) ::
+              {:ok, challenge_response() | webauthn_challenge_response()} | {:error, term()}
+  @callback verify(Client.t(), Session.t(), String.t(), String.t(), map()) ::
+              {:ok, Session.t()} | {:error, term()}
+  @callback unenroll(Client.t(), Session.t(), String.t()) ::
+              {:ok, %{id: String.t()}} | {:error, term()}
+  @callback challenge_and_verify(Client.t(), Session.t(), String.t(), String.t()) ::
+              {:ok, Session.t()} | {:error, term()}
+  @callback list_factors(Client.t(), Session.t()) ::
+              {:ok, factors_list()} | {:error, term()}
+  @callback get_authenticator_assurance_level(Client.t(), Session.t()) ::
+              {:ok, aal_response()} | {:error, term()}
+end

--- a/lib/supabase/auth/mfa_handler.ex
+++ b/lib/supabase/auth/mfa_handler.ex
@@ -1,0 +1,68 @@
+defmodule Supabase.Auth.MFAHandler do
+  @moduledoc false
+
+  alias Supabase.Auth
+  alias Supabase.Client
+  alias Supabase.Fetcher
+  alias Supabase.Fetcher.Request
+  alias Supabase.Fetcher.Response
+
+  @factors_uri "/factors"
+
+  @doc """
+  Enrolls a new MFA factor via POST /factors.
+  """
+  @spec enroll(Client.t(), String.t(), map()) :: {:ok, Response.t()} | {:error, term()}
+  def enroll(%Client{} = client, access_token, params) when is_binary(access_token) do
+    client
+    |> Auth.Request.base(@factors_uri)
+    |> Request.with_method(:post)
+    |> Request.with_headers(%{"authorization" => "Bearer #{access_token}"})
+    |> Request.with_body(params)
+    |> Fetcher.request()
+  end
+
+  @doc """
+  Creates a challenge for an MFA factor via POST /factors/{factor_id}/challenge.
+  """
+  @spec challenge(Client.t(), String.t(), String.t(), map()) ::
+          {:ok, Response.t()} | {:error, term()}
+  def challenge(%Client{} = client, access_token, factor_id, params)
+      when is_binary(access_token) and is_binary(factor_id) do
+    client
+    |> Auth.Request.base("#{@factors_uri}/#{factor_id}/challenge")
+    |> Request.with_method(:post)
+    |> Request.with_headers(%{"authorization" => "Bearer #{access_token}"})
+    |> Request.with_body(params)
+    |> Fetcher.request()
+  end
+
+  @doc """
+  Verifies an MFA challenge via POST /factors/{factor_id}/verify.
+  """
+  @spec verify(Client.t(), String.t(), String.t(), String.t(), map()) ::
+          {:ok, Response.t()} | {:error, term()}
+  def verify(%Client{} = client, access_token, factor_id, challenge_id, code_or_webauthn)
+      when is_binary(access_token) and is_binary(factor_id) and is_binary(challenge_id) do
+    body = Map.merge(%{challenge_id: challenge_id}, code_or_webauthn)
+
+    client
+    |> Auth.Request.base("#{@factors_uri}/#{factor_id}/verify")
+    |> Request.with_method(:post)
+    |> Request.with_headers(%{"authorization" => "Bearer #{access_token}"})
+    |> Request.with_body(body)
+    |> Fetcher.request()
+  end
+
+  @doc """
+  Unenrolls an MFA factor via DELETE /factors/{factor_id}.
+  """
+  @spec unenroll(Client.t(), String.t(), String.t()) :: {:ok, Response.t()} | {:error, term()}
+  def unenroll(%Client{} = client, access_token, factor_id) when is_binary(access_token) and is_binary(factor_id) do
+    client
+    |> Auth.Request.base("#{@factors_uri}/#{factor_id}")
+    |> Request.with_method(:delete)
+    |> Request.with_headers(%{"authorization" => "Bearer #{access_token}"})
+    |> Fetcher.request()
+  end
+end

--- a/lib/supabase/auth/schemas/mfa/challenge_and_verify_params.ex
+++ b/lib/supabase/auth/schemas/mfa/challenge_and_verify_params.ex
@@ -1,0 +1,20 @@
+defmodule Supabase.Auth.Schemas.MFA.ChallengeAndVerifyParams do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %{code: String.t()}
+
+  @types %{code: :string}
+
+  @spec parse(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def parse(%{code: _} = attrs) do
+    {%{}, @types}
+    |> cast(attrs, [:code])
+    |> validate_required([:code])
+    |> validate_length(:code, is: 6)
+    |> apply_action(:parse)
+  end
+end

--- a/lib/supabase/auth/schemas/mfa/challenge_params.ex
+++ b/lib/supabase/auth/schemas/mfa/challenge_params.ex
@@ -1,0 +1,60 @@
+defmodule Supabase.Auth.Schemas.MFA.ChallengeParams do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type totp :: %{}
+  @type phone :: %{channel: :sms | :whatsapp}
+  @type webauthn :: %{
+          webauthn: %{
+            rp_id: String.t(),
+            rp_origins: [String.t()] | nil
+          }
+        }
+  @type t :: totp | phone | webauthn
+
+  @phone_types %{channel: Ecto.ParameterizedType.init(Ecto.Enum, values: [:sms, :whatsapp])}
+  @webauthn_types %{webauthn: :map}
+  @webauthn_nested_types %{rp_id: :string, rp_origins: {:array, :string}}
+
+  @spec parse(phone) :: {:ok, phone} | {:error, Ecto.Changeset.t()}
+  @spec parse(webauthn) :: {:ok, webauthn} | {:error, Ecto.Changeset.t()}
+  @spec parse(totp) :: {:ok, totp} | {:error, Ecto.Changeset.t()}
+  def parse(%{channel: _} = attrs) do
+    {%{}, @phone_types}
+    |> cast(attrs, [:channel])
+    |> validate_required([:channel])
+    |> validate_inclusion(:channel, [:sms, :whatsapp])
+    |> apply_action(:parse)
+  end
+
+  def parse(%{webauthn: _} = attrs) do
+    {%{}, @webauthn_types}
+    |> cast(attrs, [:webauthn])
+    |> validate_required([:webauthn])
+    |> webauthn_changeset()
+    |> apply_action(:parse)
+  end
+
+  def parse(%{} = attrs) when map_size(attrs) == 0 do
+    {:ok, attrs}
+  end
+
+  defp webauthn_changeset(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+
+  defp webauthn_changeset(%Ecto.Changeset{} = changeset) do
+    if webauthn = get_change(changeset, :webauthn) do
+      {:ok, result} =
+        {%{}, @webauthn_nested_types}
+        |> cast(webauthn, Map.keys(@webauthn_nested_types))
+        |> validate_required([:rp_id])
+        |> apply_action(:parse)
+
+      put_change(changeset, :webauthn, result)
+    else
+      changeset
+    end
+  end
+end

--- a/lib/supabase/auth/schemas/mfa/enroll_params.ex
+++ b/lib/supabase/auth/schemas/mfa/enroll_params.ex
@@ -1,0 +1,69 @@
+defmodule Supabase.Auth.Schemas.MFA.EnrollParams do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type totp :: %{
+          factor_type: :totp,
+          friendly_name: String.t() | nil,
+          issuer: String.t() | nil
+        }
+
+  @type phone :: %{
+          factor_type: :phone,
+          friendly_name: String.t() | nil,
+          phone: String.t()
+        }
+
+  @type webauthn :: %{
+          factor_type: :webauthn,
+          friendly_name: String.t() | nil
+        }
+
+  @type t :: totp | phone | webauthn
+
+  @factor_types [:totp, :phone, :webauthn]
+
+  @totp_types %{
+    factor_type: Ecto.ParameterizedType.init(Ecto.Enum, values: @factor_types),
+    friendly_name: :string,
+    issuer: :string
+  }
+
+  @phone_types %{
+    factor_type: Ecto.ParameterizedType.init(Ecto.Enum, values: @factor_types),
+    friendly_name: :string,
+    phone: :string
+  }
+
+  @webauthn_types %{
+    factor_type: Ecto.ParameterizedType.init(Ecto.Enum, values: @factor_types),
+    friendly_name: :string
+  }
+
+  @spec parse(totp) :: {:ok, totp} | {:error, Ecto.Changeset.t()}
+  @spec parse(phone) :: {:ok, phone} | {:error, Ecto.Changeset.t()}
+  @spec parse(webauthn) :: {:ok, webauthn} | {:error, Ecto.Changeset.t()}
+  def parse(%{factor_type: :totp} = attrs) do
+    {%{}, @totp_types}
+    |> cast(attrs, [:factor_type, :friendly_name, :issuer])
+    |> validate_required([:factor_type])
+    |> apply_action(:parse)
+  end
+
+  def parse(%{factor_type: :phone} = attrs) do
+    {%{}, @phone_types}
+    |> cast(attrs, [:factor_type, :friendly_name, :phone])
+    |> validate_required([:factor_type, :phone])
+    |> apply_action(:parse)
+  end
+
+  def parse(%{factor_type: :webauthn} = attrs) do
+    {%{}, @webauthn_types}
+    |> cast(attrs, [:factor_type, :friendly_name])
+    |> validate_required([:factor_type])
+    |> apply_action(:parse)
+  end
+end

--- a/lib/supabase/auth/schemas/mfa/verify_params.ex
+++ b/lib/supabase/auth/schemas/mfa/verify_params.ex
@@ -1,0 +1,31 @@
+defmodule Supabase.Auth.Schemas.MFA.VerifyParams do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type code_params :: %{code: String.t()}
+  @type webauthn_params :: %{webauthn: map()}
+  @type t :: code_params | webauthn_params
+
+  @code_types %{code: :string}
+  @webauthn_types %{webauthn: :map}
+
+  @spec parse(code_params) :: {:ok, code_params} | {:error, Ecto.Changeset.t()}
+  @spec parse(webauthn_params) :: {:ok, webauthn_params} | {:error, Ecto.Changeset.t()}
+  def parse(%{code: _} = attrs) do
+    {%{}, @code_types}
+    |> cast(attrs, [:code])
+    |> validate_required([:code])
+    |> validate_length(:code, is: 6)
+    |> apply_action(:parse)
+  end
+
+  def parse(%{webauthn: _} = attrs) do
+    {%{}, @webauthn_types}
+    |> cast(attrs, [:webauthn])
+    |> validate_required([:webauthn])
+    |> apply_action(:parse)
+  end
+end

--- a/test/supabase/go_true/mfa_test.exs
+++ b/test/supabase/go_true/mfa_test.exs
@@ -1,0 +1,552 @@
+defmodule Supabase.Auth.MFATest do
+  use ExUnit.Case, async: true
+
+  import Mox
+  import Supabase.Auth.MFAFixture
+  import Supabase.Auth.SessionFixture
+  import Supabase.Auth.UserFixture
+
+  alias Supabase.Auth.MFA
+  alias Supabase.Auth.Session
+  alias Supabase.Fetcher.Request
+
+  @moduletag capture_log: true
+
+  setup :verify_on_exit!
+
+  @mock TestHTTPClient
+
+  setup_all do
+    Application.put_env(:supabase_auth, :http_client, @mock)
+
+    on_exit(fn ->
+      Application.delete_env(:supabase_auth, :http_client)
+    end)
+  end
+
+  setup do
+    client = Supabase.init_client!("https://localhost:54321", "test-api-key")
+    session = session_fixture(access_token: "test-token-123")
+
+    {:ok, client: client, session: session, json: Supabase.json_library()}
+  end
+
+  describe "enroll/3 with TOTP" do
+    test "successfully enrolls a TOTP factor", %{client: client, session: session, json: json} do
+      params = %{
+        factor_type: :totp,
+        friendly_name: "My Authenticator",
+        issuer: "Example"
+      }
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors"
+        assert {"authorization", "Bearer test-token-123"} in req.headers
+
+        body = json.decode!(req.body)
+        assert body["factor_type"] == "totp"
+        assert body["friendly_name"] == "My Authenticator"
+        assert body["issuer"] == "Example"
+
+        response_body = totp_factor_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, factor} = MFA.enroll(client, session, params)
+      assert factor.factor_type == :totp
+      assert factor.friendly_name == "My Authenticator"
+      assert factor.status == :unverified
+      assert factor.totp.qr_code =~ "data:image/svg+xml"
+      assert factor.totp.secret == "JBSWY3DPEHPK3PXP"
+      assert factor.totp.uri =~ "otpauth://totp/"
+    end
+
+    test "successfully enrolls a TOTP factor without optional fields", %{
+      client: client,
+      session: session
+    } do
+      params = %{factor_type: :totp}
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        response_body = totp_factor_fixture_json(%{"friendly_name" => nil})
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, factor} = MFA.enroll(client, session, params)
+      assert factor.factor_type == :totp
+      assert is_nil(factor.friendly_name)
+    end
+
+    test "returns error when enrollment fails", %{client: client, session: session} do
+      params = %{factor_type: :totp}
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        {:ok, %Finch.Response{status: 400, body: ~s|{"error": "bad request"}|, headers: []}}
+      end)
+
+      assert {:error, _} = MFA.enroll(client, session, params)
+    end
+  end
+
+  describe "enroll/3 with Phone" do
+    test "successfully enrolls a Phone factor", %{client: client, session: session, json: json} do
+      params = %{
+        factor_type: :phone,
+        phone: "+1234567890",
+        friendly_name: "My Phone"
+      }
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors"
+
+        body = json.decode!(req.body)
+        assert body["factor_type"] == "phone"
+        assert body["phone"] == "+1234567890"
+        assert body["friendly_name"] == "My Phone"
+
+        response_body = phone_factor_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, factor} = MFA.enroll(client, session, params)
+      assert factor.factor_type == :phone
+      assert factor.phone == "+1234567890"
+      assert factor.status == :unverified
+    end
+
+    test "returns error when phone is missing", %{client: client, session: session} do
+      params = %{factor_type: :phone}
+
+      assert {:error, %Ecto.Changeset{}} = MFA.enroll(client, session, params)
+    end
+  end
+
+  describe "enroll/3 with WebAuthn" do
+    test "successfully enrolls a WebAuthn factor", %{
+      client: client,
+      session: session,
+      json: json
+    } do
+      params = %{
+        factor_type: :webauthn,
+        friendly_name: "YubiKey"
+      }
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors"
+
+        body = json.decode!(req.body)
+        assert body["factor_type"] == "webauthn"
+        assert body["friendly_name"] == "YubiKey"
+
+        response_body = webauthn_factor_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, factor} = MFA.enroll(client, session, params)
+      assert factor.factor_type == :webauthn
+      assert factor.friendly_name == "YubiKey"
+    end
+  end
+
+  describe "challenge/4 with TOTP" do
+    test "successfully creates a TOTP challenge", %{client: client, session: session} do
+      factor_id = "factor-123"
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors/#{factor_id}/challenge"
+        assert {"authorization", "Bearer test-token-123"} in req.headers
+
+        response_body = totp_challenge_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, challenge} = MFA.challenge(client, session, factor_id, %{})
+      assert challenge.id == "challenge-id-123"
+      assert challenge.type == :totp
+      assert is_integer(challenge.expires_at)
+    end
+  end
+
+  describe "challenge/4 with Phone" do
+    test "successfully creates a Phone challenge via SMS", %{
+      client: client,
+      session: session,
+      json: json
+    } do
+      factor_id = "factor-456"
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors/#{factor_id}/challenge"
+
+        body = json.decode!(req.body)
+        assert body["channel"] == "sms"
+
+        response_body = phone_challenge_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, challenge} = MFA.challenge(client, session, factor_id, %{channel: :sms})
+      assert challenge.id == "challenge-id-456"
+      assert challenge.type == :phone
+    end
+
+    test "successfully creates a Phone challenge via WhatsApp", %{
+      client: client,
+      session: session,
+      json: json
+    } do
+      factor_id = "factor-456"
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        body = json.decode!(req.body)
+        assert body["channel"] == "whatsapp"
+
+        response_body = phone_challenge_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, challenge} =
+               MFA.challenge(client, session, factor_id, %{channel: :whatsapp})
+
+      assert challenge.type == :phone
+    end
+
+    test "returns error for invalid channel", %{client: client, session: session} do
+      factor_id = "factor-456"
+
+      assert {:error, %Ecto.Changeset{}} =
+               MFA.challenge(client, session, factor_id, %{channel: :invalid})
+    end
+  end
+
+  describe "challenge/4 with WebAuthn" do
+    test "successfully creates a WebAuthn challenge", %{
+      client: client,
+      session: session,
+      json: json
+    } do
+      factor_id = "factor-789"
+
+      webauthn_params = %{
+        webauthn: %{
+          rp_id: "example.com",
+          rp_origins: ["https://example.com"]
+        }
+      }
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors/#{factor_id}/challenge"
+
+        body = json.decode!(req.body)
+        assert body["webauthn"]["rp_id"] == "example.com"
+        assert body["webauthn"]["rp_origins"] == ["https://example.com"]
+
+        response_body = webauthn_challenge_fixture_json()
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, challenge} = MFA.challenge(client, session, factor_id, webauthn_params)
+      assert challenge.id == "challenge-id-789"
+      assert challenge.type == :webauthn
+      assert challenge.webauthn["type"] == "create"
+      assert is_map(challenge.webauthn["credential_options"])
+    end
+  end
+
+  describe "verify/5 with code (TOTP/Phone)" do
+    test "successfully verifies a TOTP code", %{client: client, session: session, json: json} do
+      factor_id = "factor-123"
+      challenge_id = "challenge-456"
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+        assert req.url.path =~ "/factors/#{factor_id}/verify"
+
+        body = json.decode!(req.body)
+        assert body["challenge_id"] == challenge_id
+        assert body["code"] == "123456"
+
+        user = Map.from_struct(user_fixture())
+        response_body = session_fixture_json(access_token: "new-token-789", user: user)
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, %Session{} = new_session} =
+               MFA.verify(client, session, factor_id, challenge_id, %{code: "123456"})
+
+      assert new_session.access_token == "new-token-789"
+    end
+
+    test "returns error for invalid code length", %{client: client, session: session} do
+      factor_id = "factor-123"
+      challenge_id = "challenge-456"
+
+      assert {:error, %Ecto.Changeset{}} =
+               MFA.verify(client, session, factor_id, challenge_id, %{code: "123"})
+    end
+
+    test "returns error when verification fails", %{client: client, session: session} do
+      factor_id = "factor-123"
+      challenge_id = "challenge-456"
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        {:ok, %Finch.Response{status: 400, body: ~s|{"error": "invalid code"}|, headers: []}}
+      end)
+
+      assert {:error, _} =
+               MFA.verify(client, session, factor_id, challenge_id, %{code: "000000"})
+    end
+  end
+
+  describe "verify/5 with WebAuthn" do
+    test "successfully verifies a WebAuthn credential", %{
+      client: client,
+      session: session,
+      json: json
+    } do
+      factor_id = "factor-789"
+      challenge_id = "challenge-abc"
+
+      webauthn_params = %{
+        webauthn: %{
+          type: "create",
+          rp_id: "example.com",
+          credential_response: %{"id" => "credential-123"}
+        }
+      }
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :post
+
+        body = json.decode!(req.body)
+        assert body["challenge_id"] == challenge_id
+        assert body["webauthn"]["type"] == "create"
+
+        user = Map.from_struct(user_fixture())
+        response_body = session_fixture_json(access_token: "new-token-webauthn", user: user)
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, %Session{} = new_session} =
+               MFA.verify(client, session, factor_id, challenge_id, webauthn_params)
+
+      assert new_session.access_token == "new-token-webauthn"
+    end
+  end
+
+  describe "unenroll/3" do
+    test "successfully unenrolls a factor", %{client: client, session: session, json: json} do
+      factor_id = "factor-to-delete"
+
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.method == :delete
+        assert req.url.path =~ "/factors/#{factor_id}"
+        assert {"authorization", "Bearer test-token-123"} in req.headers
+
+        response_body = json.encode!(%{"id" => factor_id})
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, %{id: ^factor_id}} = MFA.unenroll(client, session, factor_id)
+    end
+
+    test "returns error when factor doesn't exist", %{client: client, session: session} do
+      factor_id = "non-existent"
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        {:ok, %Finch.Response{status: 404, body: ~s|{"error": "not found"}|, headers: []}}
+      end)
+
+      assert {:error, _} = MFA.unenroll(client, session, factor_id)
+    end
+  end
+
+  describe "challenge_and_verify/4" do
+    test "successfully challenges and verifies in one call", %{
+      client: client,
+      session: session,
+      json: json
+    } do
+      factor_id = "totp-factor-123"
+      code = "654321"
+
+      # First call: challenge
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.url.path =~ "/factors/#{factor_id}/challenge"
+
+        response_body = totp_challenge_fixture_json(%{"id" => "challenge-xyz"})
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      # Second call: verify
+      expect(@mock, :request, fn %Request{} = req, _opts ->
+        assert req.url.path =~ "/factors/#{factor_id}/verify"
+
+        body = json.decode!(req.body)
+        assert body["challenge_id"] == "challenge-xyz"
+        assert body["code"] == code
+
+        user = Map.from_struct(user_fixture())
+        response_body = session_fixture_json(access_token: "final-token", user: user)
+
+        {:ok, %Finch.Response{status: 200, body: response_body, headers: []}}
+      end)
+
+      assert {:ok, %Session{} = new_session} =
+               MFA.challenge_and_verify(client, session, factor_id, code)
+
+      assert new_session.access_token == "final-token"
+    end
+
+    test "returns error for invalid code", %{client: client, session: session} do
+      factor_id = "totp-factor-123"
+
+      assert {:error, %Ecto.Changeset{}} =
+               MFA.challenge_and_verify(client, session, factor_id, "12")
+    end
+  end
+
+  describe "list_factors/2" do
+    test "successfully lists all factors categorized by type", %{client: client} do
+      factors = [
+        verified_totp_factor_fixture(),
+        phone_factor_fixture(),
+        verified_webauthn_factor_fixture()
+      ]
+
+      factor_structs = Enum.map(factors, &build_factor_struct/1)
+      session = session_fixture(user: %{factors: factor_structs})
+
+      assert {:ok, result} = MFA.list_factors(client, session)
+
+      assert length(result.all) == 3
+      assert length(result.totp) == 1
+      assert Enum.empty?(result.phone)
+      assert length(result.webauthn) == 1
+
+      [totp_factor] = result.totp
+      assert totp_factor.factor_type == :totp
+      assert totp_factor.status == :verified
+    end
+
+    test "returns empty lists when no factors exist", %{client: client} do
+      session = session_fixture(user: %{factors: []})
+
+      assert {:ok, result} = MFA.list_factors(client, session)
+
+      assert result.all == []
+      assert result.totp == []
+      assert result.phone == []
+      assert result.webauthn == []
+    end
+
+    test "only includes verified factors in type-specific lists", %{client: client} do
+      factors = [
+        verified_totp_factor_fixture(%{"id" => "totp-1"}),
+        totp_factor_fixture(%{"id" => "totp-2", "status" => "unverified"}),
+        verified_phone_factor_fixture(%{"id" => "phone-1"})
+      ]
+
+      factor_structs = Enum.map(factors, &build_factor_struct/1)
+      session = session_fixture(user: %{factors: factor_structs})
+
+      assert {:ok, result} = MFA.list_factors(client, session)
+
+      # All factors in 'all' list
+      assert length(result.all) == 3
+
+      # Only verified in type-specific lists
+      assert length(result.totp) == 1
+      assert length(result.phone) == 1
+    end
+  end
+
+  describe "get_authenticator_assurance_level/2" do
+    test "returns AAL1 for user without MFA", %{client: client} do
+      jwt_token = jwt_token_fixture(aal: "aal1", amr: ["password"])
+      session = session_fixture(access_token: jwt_token, user: %{factors: []})
+
+      assert {:ok, result} = MFA.get_authenticator_assurance_level(client, session)
+
+      assert result.current_level == :aal1
+      assert result.next_level == :aal1
+      assert result.current_authentication_methods == ["password"]
+    end
+
+    test "returns AAL2 for user with verified MFA", %{client: client} do
+      jwt_token = jwt_token_fixture(aal: "aal2", amr: ["password", "totp"])
+
+      verified_factor = build_factor_struct(verified_totp_factor_fixture())
+
+      session = session_fixture(access_token: jwt_token, user: %{factors: [verified_factor]})
+
+      assert {:ok, result} = MFA.get_authenticator_assurance_level(client, session)
+
+      assert result.current_level == :aal2
+      assert result.next_level == :aal2
+      assert result.current_authentication_methods == ["password", "totp"]
+    end
+
+    test "returns AAL1 with next level AAL2 when user has unverified factors", %{
+      client: client
+    } do
+      jwt_token = jwt_token_fixture(aal: "aal1", amr: ["password"])
+
+      verified_factor = build_factor_struct(verified_totp_factor_fixture())
+
+      session = session_fixture(access_token: jwt_token, user: %{factors: [verified_factor]})
+
+      assert {:ok, result} = MFA.get_authenticator_assurance_level(client, session)
+
+      assert result.current_level == :aal1
+      assert result.next_level == :aal2
+    end
+
+    test "returns error for invalid JWT", %{client: client} do
+      session = session_fixture(access_token: "invalid-jwt-token", user: %{factors: []})
+
+      assert {:error, :invalid_jwt_format} =
+               MFA.get_authenticator_assurance_level(client, session)
+    end
+  end
+
+  # Helper function to build Factor structs from fixture maps
+  defp build_factor_struct(factor_map) do
+    alias Supabase.Auth.User.Factor
+
+    %Factor{
+      id: factor_map["id"],
+      friendly_name: factor_map["friendly_name"],
+      factor_type: parse_factor_type(factor_map["type"]),
+      status: parse_factor_status(factor_map["status"]),
+      created_at: factor_map["created_at"],
+      updated_at: factor_map["updated_at"]
+    }
+  end
+
+  defp parse_factor_type("totp"), do: :totp
+  defp parse_factor_type("phone"), do: :phone
+  defp parse_factor_type("webauthn"), do: :webauthn
+
+  defp parse_factor_status("verified"), do: :verified
+  defp parse_factor_status("unverified"), do: :unverified
+end

--- a/test/support/fixtures/mfa_fixture.ex
+++ b/test/support/fixtures/mfa_fixture.ex
@@ -1,0 +1,170 @@
+defmodule Supabase.Auth.MFAFixture do
+  @moduledoc """
+  This module is used to generate fixtures for MFA-related data.
+  """
+
+  @doc "Generate a TOTP factor fixture."
+  def totp_factor_fixture(attrs \\ %{}) do
+    default = %{
+      "id" => "11111111-1111-1111-1111-111111111111",
+      "type" => "totp",
+      "friendly_name" => "My Authenticator",
+      "status" => "unverified",
+      "totp" => %{
+        "qr_code" => "data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'/>",
+        "secret" => "JBSWY3DPEHPK3PXP",
+        "uri" => "otpauth://totp/Example:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+      },
+      "created_at" => "2024-01-01T00:00:00.000000Z",
+      "updated_at" => "2024-01-01T00:00:00.000000Z",
+      "last_challenged_at" => nil
+    }
+
+    Map.merge(default, Map.new(attrs))
+  end
+
+  @doc "Generate a TOTP factor fixture as JSON."
+  def totp_factor_fixture_json(attrs \\ %{}) do
+    json = Supabase.json_library()
+    attrs |> totp_factor_fixture() |> json.encode!()
+  end
+
+  @doc "Generate a verified TOTP factor fixture."
+  def verified_totp_factor_fixture(attrs \\ %{}) do
+    totp_factor_fixture(Map.put(attrs, "status", "verified"))
+  end
+
+  @doc "Generate a Phone factor fixture."
+  def phone_factor_fixture(attrs \\ %{}) do
+    default = %{
+      "id" => "22222222-2222-2222-2222-222222222222",
+      "type" => "phone",
+      "friendly_name" => "My Phone",
+      "status" => "unverified",
+      "phone" => "+1234567890",
+      "created_at" => "2024-01-01T00:00:00.000000Z",
+      "updated_at" => "2024-01-01T00:00:00.000000Z",
+      "last_challenged_at" => nil
+    }
+
+    Map.merge(default, Map.new(attrs))
+  end
+
+  @doc "Generate a Phone factor fixture as JSON."
+  def phone_factor_fixture_json(attrs \\ %{}) do
+    json = Supabase.json_library()
+    attrs |> phone_factor_fixture() |> json.encode!()
+  end
+
+  @doc "Generate a verified Phone factor fixture."
+  def verified_phone_factor_fixture(attrs \\ %{}) do
+    phone_factor_fixture(Map.put(attrs, "status", "verified"))
+  end
+
+  @doc "Generate a WebAuthn factor fixture."
+  def webauthn_factor_fixture(attrs \\ %{}) do
+    default = %{
+      "id" => "33333333-3333-3333-3333-333333333333",
+      "type" => "webauthn",
+      "friendly_name" => "YubiKey",
+      "status" => "unverified",
+      "created_at" => "2024-01-01T00:00:00.000000Z",
+      "updated_at" => "2024-01-01T00:00:00.000000Z",
+      "last_challenged_at" => nil
+    }
+
+    Map.merge(default, Map.new(attrs))
+  end
+
+  @doc "Generate a WebAuthn factor fixture as JSON."
+  def webauthn_factor_fixture_json(attrs \\ %{}) do
+    json = Supabase.json_library()
+    attrs |> webauthn_factor_fixture() |> json.encode!()
+  end
+
+  @doc "Generate a verified WebAuthn factor fixture."
+  def verified_webauthn_factor_fixture(attrs \\ %{}) do
+    webauthn_factor_fixture(Map.put(attrs, "status", "verified"))
+  end
+
+  @doc "Generate a TOTP challenge response fixture."
+  def totp_challenge_fixture(attrs \\ %{}) do
+    default = %{
+      "id" => "challenge-id-123",
+      "type" => "totp",
+      "expires_at" => 1_735_689_600
+    }
+
+    Map.merge(default, Map.new(attrs))
+  end
+
+  @doc "Generate a TOTP challenge response fixture as JSON."
+  def totp_challenge_fixture_json(attrs \\ %{}) do
+    json = Supabase.json_library()
+    attrs |> totp_challenge_fixture() |> json.encode!()
+  end
+
+  @doc "Generate a Phone challenge response fixture."
+  def phone_challenge_fixture(attrs \\ %{}) do
+    default = %{
+      "id" => "challenge-id-456",
+      "type" => "phone",
+      "expires_at" => 1_735_689_600
+    }
+
+    Map.merge(default, Map.new(attrs))
+  end
+
+  @doc "Generate a Phone challenge response fixture as JSON."
+  def phone_challenge_fixture_json(attrs \\ %{}) do
+    json = Supabase.json_library()
+    attrs |> phone_challenge_fixture() |> json.encode!()
+  end
+
+  @doc "Generate a WebAuthn challenge response fixture."
+  def webauthn_challenge_fixture(attrs \\ %{}) do
+    default = %{
+      "id" => "challenge-id-789",
+      "type" => "webauthn",
+      "expires_at" => 1_735_689_600,
+      "webauthn" => %{
+        "type" => "create",
+        "credential_options" => %{
+          "publicKey" => %{
+            "challenge" => "abc123",
+            "rp" => %{"name" => "Example", "id" => "example.com"}
+          }
+        }
+      }
+    }
+
+    Map.merge(default, Map.new(attrs))
+  end
+
+  @doc "Generate a WebAuthn challenge response fixture as JSON."
+  def webauthn_challenge_fixture_json(attrs \\ %{}) do
+    json = Supabase.json_library()
+    attrs |> webauthn_challenge_fixture() |> json.encode!()
+  end
+
+  @doc "Generate a JWT token with AAL claims."
+  def jwt_token_fixture(attrs \\ []) do
+    attrs = Map.new(attrs)
+    aal = Map.get(attrs, :aal, "aal1")
+    amr = Map.get(attrs, :amr, ["password"])
+
+    claims = %{
+      "aal" => aal,
+      "amr" => amr,
+      "sub" => "11111111-1111-1111-1111-111111111111",
+      "exp" => 9_999_999_999
+    }
+
+    json = Supabase.json_library()
+    payload = json.encode!(claims)
+    encoded_payload = Base.url_encode64(payload, padding: false)
+
+    # JWT structure: header.payload.signature
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.#{encoded_payload}.signature"
+  end
+end


### PR DESCRIPTION
## Problem

The Elixir SDK was missing the Multi-Factor Authentication (MFA) namespace for managing TOTP, Phone, and WebAuthn factors. This addresses issue #54.

## Solution

Implemented the complete MFA namespace with 7 public API functions:

- `enroll/3` - Enroll new MFA factors (TOTP, Phone, WebAuthn)
- `challenge/4` - Create verification challenges
- `verify/5` - Verify challenges and upgrade to AAL2 session
- `unenroll/3` - Remove MFA factors
- `challenge_and_verify/4` - TOTP convenience function
- `list_factors/2` - List factors categorized by type
- `get_authenticator_assurance_level/2` - Get AAL from JWT

### New Modules

- `Supabase.Auth.MFA` - Main public API
- `Supabase.Auth.MFA.Behaviour` - Type definitions and callbacks
- `Supabase.Auth.MFAHandler` - HTTP operations
- `Supabase.Auth.Schemas.MFA.*` - Input validation (4 modules)


## Rationale

**Lightweight approach**: Used typespecs and schemaless Ecto changesets instead of Ecto schemas. Keeps the implementation simple and focused on validation.

**Pattern matching for polymorphism**: Multiple function clauses handle different factor types cleanly without complex conditionals.

**Dedicated behaviour module**: Centralizes all MFA type definitions as single source of truth.

**Categorized factor lists**: Returns factors grouped by type (`%{all: [], totp: [], phone: [], webauthn: []}`) for convenient access.

**JWT decoding**: Extracts AAL claims from session token without HTTP calls or additional dependencies.

Follows existing project patterns (`verify_otp.ex`, `UserHandler`) with comprehensive documentation and test coverage.
