### PR TITLE
fix: include options.data in sign up payload

### DIFF
--- a/lib/supabase/auth/schemas/sign_up_with_password.ex
+++ b/lib/supabase/auth/schemas/sign_up_with_password.ex
@@ -35,7 +35,9 @@ defmodule Supabase.Auth.Schemas.SignUpWithPassword do
   end
 
   def to_sign_up_params(%__MODULE__{} = signup) do
-    Map.take(signup, [:email, :password, :phone])
+    signup
+    |> Map.take([:email, :password, :phone])
+    |> Map.put(:data, (signup.options && signup.options.data) || %{})
   end
 
   def to_sign_up_params(%__MODULE__{} = signup, code_challenge, code_method) do


### PR DESCRIPTION
## Problem

When using [`sign_up/2`](https://hexdocs.pm/supabase_auth/Supabase.Auth.html#sign_up/2) there is a parameter `options.data` which allows for passing extra data to include with sign up, such as the `display_name` for the user (see example below). According to [Supabase docs](https://supabase.com/docs/guides/auth/managing-user-data#adding-and-retrieving-user-metadata), this data is stored in `raw_user_meta_data` column of the `auth.users` table.

```elixir
{:ok, user} = Supabase.Auth.sign_up(client, %{
  email: user_params["email"],
  password: user_params["password"],
  options: %{
    data: %{
      display_name: user_params["display_name"]
    },
  },
})
```

I've noticed however that in this library, `options.data` is never passed into Supabase. 

## Solution

This PR fixes the issue of `options.data` not being passed into Supabase by including them in the request. The tests were written to verify the functionality, and the solution was tested manually by installing it into another project where I've verified that the `data` is now being passed to Supabase.

## Rationale

This change aligns the library’s behavior with both its documented API and Supabase Auth’s documented behavior. It is backwards compatible as well.
