### PR TITLE
fix: correctly build the client key for auto-refresh registry name

### DIFF
--- a/lib/supabase/auth/auto_refresh.ex
+++ b/lib/supabase/auth/auto_refresh.ex
@@ -113,6 +113,6 @@ defmodule Supabase.Auth.AutoRefresh do
   end
 
   defp client_key(client) do
-    "auth_refresh:#{client.base_url}|#{client.auth.url}"
+    "auth_refresh:#{client.auth_url}|#{client.auth.storage_key}"
   end
 end

--- a/test/supabase/go_true/auto_refresh_test.exs
+++ b/test/supabase/go_true/auto_refresh_test.exs
@@ -12,9 +12,9 @@ defmodule Supabase.Auth.AutoRefreshTest do
 
   setup do
     client = %Client{
-      base_url: "https://example.supabase.co",
+      auth_url: "https://example.supabase.co/auth/v1",
       api_key: "test-api-key",
-      auth: %{url: "https://example.supabase.co/auth/v1"}
+      auth: %{storage_key: "sb-test-key"}
     }
 
     session = %Session{


### PR DESCRIPTION
## Problem

typo on `client_key/1` was trying to access the unknown `client.auth.url` key

## Solution

fixed the type and now correctly uses `client.auth_url` + `client.auth.storage_key` as `client_key/1`

## Rationale

avoid `Supabase.Auth.AutoRefresh` to raise exceptions on start because of unknown key `client.auth.url` as part of the via tuple process name on registry
