### PR TITLE
fix: include user_metadata parsing in user

### DIFF
--- a/lib/supabase/auth/user.ex
+++ b/lib/supabase/auth/user.ex
@@ -80,7 +80,7 @@ defmodule Supabase.Auth.User do
         }
 
   @required_fields ~w[id app_metadata aud created_at]a
-  @optional_fields ~w[confirmation_sent_at recovery_sent_at email_change_sent_at new_email new_phone invited_at action_link email phone confirmed_at email_confirmed_at phone_confirmed_at last_sign_in_at role is_anonymous]a
+  @optional_fields ~w[user_metadata confirmation_sent_at recovery_sent_at email_change_sent_at new_email new_phone invited_at action_link email phone confirmed_at email_confirmed_at phone_confirmed_at last_sign_in_at role is_anonymous]a
 
   @derive Code.ensure_loaded!(Supabase) && Module.concat(Supabase.json_library(), Encoder)
   @primary_key {:id, :binary_id, autogenerate: false}
@@ -164,7 +164,7 @@ defmodule Supabase.Auth.User do
   Parses a list of user attribute maps into a list of User structs.
 
   This function attempts to validate and parse each map in the provided list.
-  If all validations succeed, it returns a list of User structs. If any 
+  If all validations succeed, it returns a list of User structs. If any
   validation fails, it returns the first error encountered.
 
   ## Parameters

--- a/test/supabase/go_true_test.exs
+++ b/test/supabase/go_true_test.exs
@@ -672,6 +672,25 @@ defmodule Supabase.AuthTest do
       assert {:ok, %Session{} = session} = Auth.sign_up(client, data)
       assert session.user.id == "123"
     end
+
+    test "returns user_metadata", %{client: client} do
+      data = %{
+        email: "another@example.com",
+        password: "123",
+        phone: "+5522123456789",
+        options: %{captcha_token: "123", email_redirect_to: "http://localhost:3000"}
+      }
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        user = [user_metadata: %{display_name: "Example User"}] |> user_fixture() |> Map.from_struct()
+        body = session_fixture_json(user: user)
+
+        {:ok, %Finch.Response{status: 201, body: body, headers: []}}
+      end)
+
+      assert {:ok, %Session{} = session} = Auth.sign_up(client, data)
+      assert session.user.user_metadata["display_name"] == "Example User"
+    end
   end
 
   describe "reset_password_for_email/3" do


### PR DESCRIPTION
## Problem

I noticed that `user_metadata` in `Supabase.Auth.User` was not getting parsed despite being present in the response payload. This PR adds the field into the list of fields to parse, and a verification test.

## Solution

Adding the `user_metadata` to `optional_fields` fixes this issue, as verified by manual testing and an automated test.

## Rationale

The solution seems the most minimal and native to the existing code.
