### PR TITLE
fix: handle different responses from sign_up baed on user auto-confirm settings

### DIFF
--- a/lib/supabase/auth.ex
+++ b/lib/supabase/auth.ex
@@ -1,7 +1,7 @@
 defmodule Supabase.Auth do
   @moduledoc """
   The main interface for interacting with Supabase's Auth authentication service.
-  This module provides comprehensive functionality for user authentication, session management, 
+  This module provides comprehensive functionality for user authentication, session management,
   and identity handling in Elixir applications.
 
   ## Features
@@ -79,7 +79,7 @@ defmodule Supabase.Auth do
       iex> {:ok, user} = Supabase.Auth.get_user(client, session)
       iex> user.email
       "user@example.com"
-      
+
       # If the session is invalid or expired
       iex> {:error, %Supabase.Error{code: :unauthorized}} = Supabase.Auth.get_user(client, invalid_session)
   """
@@ -93,7 +93,7 @@ defmodule Supabase.Auth do
   @doc """
   Signs in a user with ID token.
 
-  This method allows authentication using ID tokens issued by supported external providers like Google, Apple, Azure, etc. 
+  This method allows authentication using ID tokens issued by supported external providers like Google, Apple, Azure, etc.
   The provider's ID token is verified and used to create or authenticate a user in the Supabase system.
 
   ## Parameters
@@ -112,7 +112,7 @@ defmodule Supabase.Auth do
 
   ## Examples
       iex> credentials = %{
-      ...>   provider: "google", 
+      ...>   provider: "google",
       ...>   token: "eyJhbGciO..." # ID token from Google
       ...> }
       iex> Supabase.Auth.sign_in_with_id_token(client, credentials)
@@ -192,7 +192,7 @@ defmodule Supabase.Auth do
       iex> credentials = %{email: "user@example.com"}
       iex> Supabase.Auth.sign_in_with_otp(client, credentials)
       :ok
-      
+
       iex> credentials = %{phone: "+15555550123", options: %{channel: "sms"}}
       iex> Supabase.Auth.sign_in_with_otp(client, credentials)
       {:ok, "message-id-123"}
@@ -213,7 +213,7 @@ defmodule Supabase.Auth do
   ## Parameters
     - `client` - The `Supabase` client to use for the request.
     - `params` - The parameters to use for the verification. Use one of the following formats:
-      
+
       For email verification:
       * `email` - The email address that received the OTP
       * `token` - The OTP code that was sent
@@ -221,7 +221,7 @@ defmodule Supabase.Auth do
       * `options` - Optional parameters:
         * `redirect_to` - URL to redirect to after verification
         * `captcha_token` - Verification token from CAPTCHA challenge
-      
+
       For phone verification:
       * `phone` - The phone number that received the OTP
       * `token` - The OTP code that was sent
@@ -229,7 +229,7 @@ defmodule Supabase.Auth do
       * `options` - Optional parameters:
         * `redirect_to` - URL to redirect to after verification
         * `captcha_token` - Verification token from CAPTCHA challenge
-      
+
       For token hash verification:
       * `token_hash` - The token hash to verify
       * `type` - The verification type (same as email verification types)
@@ -243,7 +243,7 @@ defmodule Supabase.Auth do
       iex> params = %{email: "user@example.com", token: "123456", type: :signup}
       iex> Supabase.Auth.verify_otp(client, params)
       {:ok, %Supabase.Auth.Session{}}
-      
+
       iex> params = %{phone: "+15555550123", token: "123456", type: :sms}
       iex> Supabase.Auth.verify_otp(client, params)
       {:ok, %Supabase.Auth.Session{}}
@@ -314,14 +314,14 @@ defmodule Supabase.Auth do
       iex> {:ok, session} = Supabase.Auth.sign_in_with_password(client, credentials)
       iex> session.access_token
       "eyJhbG..."
-      
+
       # Sign in with phone
       iex> credentials = %{phone: "+15555550123", password: "secure-password"}
       iex> {:ok, session} = Supabase.Auth.sign_in_with_password(client, credentials)
-      
+
       # Sign in with additional options
       iex> credentials = %{
-      ...>   email: "user@example.com", 
+      ...>   email: "user@example.com",
       ...>   password: "secure-password",
       ...>   options: %{captcha_token: "verify-token-123"}
       ...> }
@@ -360,7 +360,7 @@ defmodule Supabase.Auth do
   ## Examples
       iex> Supabase.Auth.sign_in_anonymously(client)
       {:ok, %Supabase.Auth.Session{}}
-      
+
       iex> Supabase.Auth.sign_in_anonymously(client, %{data: %{user_metadata: %{locale: "en-US"}}})
       {:ok, %Supabase.Auth.Session{}}
   """
@@ -375,6 +375,8 @@ defmodule Supabase.Auth do
   @doc """
   Signs up a user with email/phone and password.
 
+  ⚠️ The return value depends on the Supabase Auth configuration (email confirmation, auto-confirm, and PKCE).
+
   ## Parameters
     - `client` - The `Supabase` client to use for the request.
     - `credentials` - The credentials to use for the sign up:
@@ -386,10 +388,32 @@ defmodule Supabase.Auth do
         * `data` - Additional data to include with the sign up
         * `captcha_token` - Verification token from CAPTCHA challenge
 
+  ## Return values
+
+  - `{:ok, %Supabase.Auth.User{}}`
+    Returned when email confirmation is required and no session is issued.
+
+  - `{:ok, %Supabase.Auth.Session{}}`
+    Returned when auto-confirm is enabled.
+
+  - `{:ok, %Supabase.Auth.Session{}, challenge}`
+    Returned when PKCE flow is enabled.
+
+  - `{:error, changeset | error}`
+    Returned on validation or API failure.
+
   ## Examples
+
       iex> credentials = %{email: "user@example.com", password: "secure-password"}
-      iex> Supabase.Auth.sign_up(client, credentials)
-      {:ok, %Supabase.Auth.User{}}
+      iex> {:ok, result} = Supabase.Auth.sign_up(client, credentials)
+      iex> case result do
+      ...>   %Supabase.Auth.Session{} ->
+      ...>     "user logged in"
+      ...>
+      ...>   %Supabase.Auth.User{} ->
+      ...>     "user needs confirmation"
+      ...> end
+      "user logged in"
   """
   @impl true
   def sign_up(%Client{} = client, credentials) do
@@ -470,7 +494,7 @@ defmodule Supabase.Auth do
         iex> params = %{email: "another@example.com", password: "new-pass"}
         iex> Supabase.Auth.update_user(client, conn, params)
         {:ok, conn}
-        
+
         iex> params = %{data: %{name: "John Doe", avatar_url: "https://example.com/avatar.png"}}
         iex> Supabase.Auth.update_user(client, conn, params)
         {:ok, conn}
@@ -631,7 +655,7 @@ defmodule Supabase.Auth do
     * `code_verifier` - The original code verifier that was used to generate the code challenge.
     * `opts` - Additional options:
       * `redirect_to` - The URL to redirect to after successful authentication.
-      
+
   ## Examples
       iex> auth_code = "received_auth_code"
       iex> code_verifier = "original_code_verifier"
@@ -648,7 +672,7 @@ defmodule Supabase.Auth do
   @doc """
   Sends a reauthentication request for the authenticated user.
 
-  This method is typically used when performing sensitive operations that require 
+  This method is typically used when performing sensitive operations that require
   recent authentication. It sends a one-time password (OTP) to the user's email
   or phone number, which they need to verify to confirm their identity.
 

--- a/lib/supabase/auth/behaviour.ex
+++ b/lib/supabase/auth/behaviour.ex
@@ -35,7 +35,11 @@ defmodule Supabase.Auth.Behaviour do
 
   @callback sign_in_anonymously(Client.t(), SignInAnonymously.t()) :: sign_in_response
 
-  @callback sign_up(Client.t(), map()) :: {:ok, User.t()} | {:error, term()}
+  @callback sign_up(Client.t(), map()) ::
+              {:ok, User.t()}
+              | {:ok, Session.t()}
+              | {:ok, Session.t(), binary()}
+              | {:error, Ecto.Changeset.t() | Supabase.Error.t() | term()}
 
   @callback reset_password_for_email(Client.t(), String.t(), opts) :: :ok | {:error, term()}
             when opts:

--- a/lib/supabase/auth/user_handler.ex
+++ b/lib/supabase/auth/user_handler.ex
@@ -16,6 +16,7 @@ defmodule Supabase.Auth.UserHandler do
   alias Supabase.Auth.Schemas.SignUpWithPassword
   alias Supabase.Auth.Schemas.VerifyOTP
   alias Supabase.Auth.Session
+  alias Supabase.Auth.User
   alias Supabase.Client
   alias Supabase.Fetcher
   alias Supabase.Fetcher.Request
@@ -170,8 +171,8 @@ defmodule Supabase.Auth.UserHandler do
            |> Request.with_method(:post)
            |> Request.with_body(body)
            |> Fetcher.request(),
-         {:ok, session} <- Session.parse(resp.body) do
-      {:ok, session, challenge}
+         {:ok, result} <- parse_signup_response(resp.body) do
+      {:ok, result, challenge}
     end
   end
 
@@ -183,7 +184,17 @@ defmodule Supabase.Auth.UserHandler do
            |> Request.with_method(:post)
            |> Request.with_body(body)
            |> Fetcher.request() do
-      Session.parse(resp.body)
+      parse_signup_response(resp.body)
+    end
+  end
+
+  def parse_signup_response(body) do
+    case Session.parse(body) do
+      {:ok, session} ->
+        {:ok, session}
+
+      {:error, _} ->
+        User.parse(body)
     end
   end
 

--- a/pages/auth_guide.md
+++ b/pages/auth_guide.md
@@ -125,7 +125,7 @@ children = [
 Create a new user with email and password:
 
 ```elixir
-{:ok, user} = Supabase.Auth.sign_up(client, %{
+{:ok, user_or_session} = Supabase.Auth.sign_up(client, %{
   email: "new_user@example.com",
   password: "securepassword"
 })

--- a/test/support/fixtures/error_fixture.ex
+++ b/test/support/fixtures/error_fixture.ex
@@ -1,0 +1,31 @@
+defmodule Supabase.Auth.ErrorFixture do
+  @moduledoc """
+  This module is used to generate fixtures for the `Supabase.Error` schema.
+  """
+
+  alias Supabase.Error
+
+  @doc "Generate a error fixture."
+  def error_fixture(attrs \\ %{}) do
+    default = %{
+      code: :not_found,
+      message: "Resource Not Found",
+      service: :storage,
+      metadata: %{
+        path: "/api/resource",
+        req_body: %{},
+        resp_body: "Not found",
+        headers: [{"content-type", "application/json"}]
+      }
+    }
+
+    attrs
+    |> Map.new()
+    |> Enum.into(default)
+    |> then(&struct(Error, &1))
+  end
+
+  def error_fixture_json(attrs \\ %{}) do
+    attrs |> error_fixture() |> Supabase.encode_json()
+  end
+end


### PR DESCRIPTION
## Problem

Current sign up code assumes that `sign_up` will always return `Supabase.Session`. However, that is not always the case - if we turn on "Confirm email" functionality in Supabase, the users will need to confirm their email before they can log in (see image below). As a result, `sign_up` will return `Supabase.User` instead. This means that the function doesn't work correctly when this setting is turned on.

<img width="1155" height="94" alt="image" src="https://github.com/user-attachments/assets/3e274b24-1a47-4593-a8fa-ce9e00cfad9c" />


## Solution

I've added a function that properly handles both types of responses - `Supabase.Session` and `Supabase.User` and then use them in both versions of `sign_up`. I've tested this using automated tests and in my backend. I've also updated the docs to be clearer on what the possible return values are. I've also added tests to verify that errors are being properly returned.

## Rationale

To me this seems like the best approach that unifies both responses with minimal lift required, but open to other suggestions.