### PR TITLE
feat: add OAuth response schemas

### DIFF
--- a/lib/supabase/auth/schemas/oauth/authorization_details.ex
+++ b/lib/supabase/auth/schemas/oauth/authorization_details.ex
@@ -1,0 +1,109 @@
+defmodule Supabase.Auth.Schemas.OAuth.AuthorizationDetails do
+  @moduledoc """
+  Schema for OAuth authorization request details using schemaless changesets.
+
+  Contains information about an OAuth authorization request, including
+  the requesting client, user, and requested scopes.
+
+  ## Early-Exit Scenario
+
+  If the `redirect_url` field is present, the user has already consented
+  to this authorization request and should be redirected immediately without
+  showing a consent screen.
+
+  ## Examples
+
+      # User needs to provide consent
+      %{
+        authorization_id: "auth-123",
+        redirect_url: nil,
+        client: %{id: "client-123", name: "My App", ...},
+        user: %{id: "user-123", email: "user@example.com"},
+        scope: "read write"
+      }
+
+      # User already consented (early-exit)
+      %{
+        authorization_id: "auth-123",
+        redirect_url: "https://app.com/callback?code=...",
+        client: %{...},
+        user: %{...},
+        scope: "read write"
+      }
+  """
+
+  import Ecto.Changeset
+
+  alias Supabase.Auth.Schemas.OAuth.Client
+
+  @type t :: %{
+          authorization_id: String.t(),
+          redirect_url: String.t() | nil,
+          client: Client.t(),
+          user: %{id: String.t(), email: String.t()},
+          scope: String.t()
+        }
+
+  @types %{
+    authorization_id: :string,
+    redirect_url: :string,
+    scope: :string
+  }
+
+  @user_types %{
+    id: :string,
+    email: :string
+  }
+
+  @doc """
+  Parses OAuth authorization details from API response.
+
+  Returns `{:ok, map}` with parsed authorization details or `{:error, changeset}` if validation fails.
+
+  ## Examples
+
+      iex> AuthorizationDetails.parse(%{
+      ...>   "authorization_id" => "auth-123",
+      ...>   "redirect_url" => nil,
+      ...>   "client" => %{"id" => "c1", "name" => "App", "uri" => "https://app.com"},
+      ...>   "user" => %{"id" => "u1", "email" => "user@example.com"},
+      ...>   "scope" => "read write"
+      ...> })
+      {:ok, %{
+        authorization_id: "auth-123",
+        redirect_url: nil,
+        client: %{id: "c1", name: "App", uri: "https://app.com", logo_uri: nil},
+        user: %{id: "u1", email: "user@example.com"},
+        scope: "read write"
+      }}
+  """
+  @spec parse(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def parse(attrs) do
+    with {:ok, client} <- Client.parse(attrs["client"] || %{}),
+         {:ok, user} <- parse_user(attrs["user"] || %{}) do
+      {%{}, @types}
+      |> cast(attrs, Map.keys(@types))
+      |> validate_required([:authorization_id, :scope])
+      |> apply_action(:parse)
+      |> case do
+        {:ok, details} ->
+          {:ok,
+           details
+           |> Map.put(:client, client)
+           |> Map.put(:user, user)
+           |> Map.put_new(:redirect_url, nil)}
+
+        error ->
+          error
+      end
+    end
+  end
+
+  @spec parse_user(map()) :: {:ok, %{id: String.t(), email: String.t()}} | {:error, Ecto.Changeset.t()}
+  defp parse_user(user_data) do
+    {%{}, @user_types}
+    |> cast(user_data, Map.keys(@user_types))
+    |> validate_required([:id, :email])
+    |> apply_action(:parse)
+  end
+end

--- a/lib/supabase/auth/schemas/oauth/client.ex
+++ b/lib/supabase/auth/schemas/oauth/client.ex
@@ -1,0 +1,59 @@
+defmodule Supabase.Auth.Schemas.OAuth.Client do
+  @moduledoc """
+  Schema for OAuth client representation using schemaless changesets.
+
+  OAuth clients represent third-party applications that can request
+  authorization from users.
+  """
+
+  import Ecto.Changeset
+
+  @type t :: %{
+          id: String.t(),
+          name: String.t(),
+          uri: String.t(),
+          logo_uri: String.t() | nil
+        }
+
+  @types %{
+    id: :string,
+    name: :string,
+    uri: :string,
+    logo_uri: :string
+  }
+
+  @doc """
+  Parses OAuth client data from API response.
+
+  Returns `{:ok, map}` with parsed client data or `{:error, changeset}` if validation fails.
+
+  ## Examples
+
+      iex> Client.parse(%{
+      ...>   "id" => "client-123",
+      ...>   "name" => "My App",
+      ...>   "uri" => "https://example.com",
+      ...>   "logo_uri" => "https://example.com/logo.png"
+      ...> })
+      {:ok, %{
+        id: "client-123",
+        name: "My App",
+        uri: "https://example.com",
+        logo_uri: "https://example.com/logo.png"
+      }}
+
+      iex> Client.parse(%{})
+      {:error, %Ecto.Changeset{}}
+  """
+  @spec parse(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def parse(attrs) do
+    {%{}, @types}
+    |> cast(attrs, Map.keys(@types))
+    |> validate_required([:id, :name, :uri])
+    |> apply_action(:parse)
+    |> case do
+      {:ok, client} -> {:ok, Map.put_new(client, :logo_uri, nil)}
+      error -> error
+    end
+  end
+end

--- a/lib/supabase/auth/schemas/oauth/consent_response.ex
+++ b/lib/supabase/auth/schemas/oauth/consent_response.ex
@@ -1,0 +1,47 @@
+defmodule Supabase.Auth.Schemas.OAuth.ConsentResponse do
+  @moduledoc """
+  Schema for OAuth consent response using schemaless changesets.
+
+  Contains the redirect URL to continue the OAuth flow after
+  the user approves or denies the authorization request.
+
+  ## Examples
+
+      %{
+        redirect_url: "https://app.com/callback?code=abc123..."
+      }
+  """
+
+  import Ecto.Changeset
+
+  @type t :: %{
+          redirect_url: String.t()
+        }
+
+  @types %{
+    redirect_url: :string
+  }
+
+  @doc """
+  Parses OAuth consent response from API response.
+
+  Returns `{:ok, map}` with parsed consent response or `{:error, changeset}` if validation fails.
+
+  ## Examples
+
+      iex> ConsentResponse.parse(%{
+      ...>   "redirect_url" => "https://app.com/callback?code=abc123"
+      ...> })
+      {:ok, %{redirect_url: "https://app.com/callback?code=abc123"}}
+
+      iex> ConsentResponse.parse(%{})
+      {:error, %Ecto.Changeset{}}
+  """
+  @spec parse(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def parse(attrs) do
+    {%{}, @types}
+    |> cast(attrs, Map.keys(@types))
+    |> validate_required([:redirect_url])
+    |> apply_action(:parse)
+  end
+end

--- a/lib/supabase/auth/schemas/oauth/grant.ex
+++ b/lib/supabase/auth/schemas/oauth/grant.ex
@@ -1,0 +1,89 @@
+defmodule Supabase.Auth.Schemas.OAuth.Grant do
+  @moduledoc """
+  Schema for OAuth grant representation using schemaless changesets.
+
+  OAuth grants represent user authorization to a third-party client application.
+  """
+
+  import Ecto.Changeset
+
+  alias Supabase.Auth.Schemas.OAuth.Client
+
+  @type t :: %{
+          client: Client.t(),
+          scopes: [String.t()],
+          granted_at: String.t()
+        }
+
+  @types %{
+    scopes: {:array, :string},
+    granted_at: :string
+  }
+
+  @doc """
+  Parses OAuth grant data from API response.
+
+  Returns `{:ok, map}` with parsed grant data or `{:error, changeset}` if validation fails.
+
+  ## Examples
+
+      iex> Grant.parse(%{
+      ...>   "client" => %{
+      ...>     "id" => "client-123",
+      ...>     "name" => "My App",
+      ...>     "uri" => "https://example.com"
+      ...>   },
+      ...>   "scopes" => ["read", "write"],
+      ...>   "granted_at" => "2024-01-01T00:00:00Z"
+      ...> })
+      {:ok, %{
+        client: %{id: "client-123", name: "My App", uri: "https://example.com", logo_uri: nil},
+        scopes: ["read", "write"],
+        granted_at: "2024-01-01T00:00:00Z"
+      }}
+
+      iex> Grant.parse(%{})
+      {:error, %Ecto.Changeset{}}
+  """
+  @spec parse(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def parse(attrs) do
+    with {:ok, client} <- Client.parse(attrs["client"] || %{}) do
+      {%{}, @types}
+      |> cast(attrs, Map.keys(@types))
+      |> validate_required([:scopes, :granted_at])
+      |> apply_action(:parse)
+      |> case do
+        {:ok, grant} -> {:ok, Map.put(grant, :client, client)}
+        error -> error
+      end
+    end
+  end
+
+  @doc """
+  Parses a list of OAuth grants from API response.
+
+  Returns `{:ok, [grant_map]}` with a list of parsed grants or `{:error, reason}` if any grant fails to parse.
+
+  ## Examples
+
+      iex> Grant.parse_list([
+      ...>   %{"client" => %{"id" => "c1", "name" => "App 1", "uri" => "https://app1.com"}, "scopes" => ["read"], "granted_at" => "2024-01-01T00:00:00Z"},
+      ...>   %{"client" => %{"id" => "c2", "name" => "App 2", "uri" => "https://app2.com"}, "scopes" => ["write"], "granted_at" => "2024-01-02T00:00:00Z"}
+      ...> ])
+      {:ok, [%{client: %{...}, scopes: ["read"], ...}, %{client: %{...}, scopes: ["write"], ...}]}
+  """
+  @spec parse_list([map()]) :: {:ok, [t()]} | {:error, term()}
+  def parse_list(data) when is_list(data) do
+    data
+    |> Enum.reduce_while({:ok, []}, fn item, {:ok, acc} ->
+      case parse(item) do
+        {:ok, grant} -> {:cont, {:ok, [grant | acc]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, grants} -> {:ok, Enum.reverse(grants)}
+      error -> error
+    end
+  end
+end


### PR DESCRIPTION
Add Client, Grant, AuthorizationDetails, and ConsentResponse schemas
using Ecto schemaless changesets.

Related to #71
