### PR TITLE
feat: weak password error parsing

### DIFF
--- a/lib/supabase/auth.ex
+++ b/lib/supabase/auth.ex
@@ -54,6 +54,7 @@ defmodule Supabase.Auth do
   alias Supabase.Auth.Session
   alias Supabase.Auth.User
   alias Supabase.Auth.UserHandler
+  alias Supabase.Auth.WeakPasswordError
   alias Supabase.Client
 
   @doc """
@@ -417,8 +418,9 @@ defmodule Supabase.Auth do
   """
   @impl true
   def sign_up(%Client{} = client, credentials) do
-    with {:ok, credentials} <- SignUpWithPassword.parse(credentials) do
-      UserHandler.sign_up(client, credentials)
+    with {:ok, credentials} <- SignUpWithPassword.parse(credentials),
+         {:error, %Supabase.Error{} = err} <- UserHandler.sign_up(client, credentials) do
+      {:error, WeakPasswordError.maybe_enrich(err)}
     end
   end
 
@@ -501,12 +503,10 @@ defmodule Supabase.Auth do
     """
     @impl true
     def update_user(%Client{} = client, conn, attrs) do
-      with {:ok, params} <- UserParams.parse(attrs) do
-        if conn.assigns.current_user do
-          UserHandler.update_user(client, conn, params)
-        else
-          {:error, :no_user_logged_in}
-        end
+      with {:ok, params} <- UserParams.parse(attrs),
+           :ok <- if(conn.assigns.current_user, do: :ok, else: {:error, :no_user_logged_in}),
+           {:error, %Supabase.Error{} = err} <- UserHandler.update_user(client, conn, params) do
+        {:error, WeakPasswordError.maybe_enrich(err)}
       end
     end
   end

--- a/lib/supabase/auth/weak_password_error.ex
+++ b/lib/supabase/auth/weak_password_error.ex
@@ -1,0 +1,102 @@
+defmodule Supabase.Auth.WeakPasswordError do
+  @moduledoc """
+  Helpers for working with weak password errors from GoTrue.
+
+  GoTrue returns structured weak password data in error responses:
+
+      %{
+        "error_code" => "weak_password",
+        "msg" => "Password too short",
+        "weak_password" => %{"reasons" => ["length"]}
+      }
+
+  The default `Supabase.HTTPErrorParser` preserves this in `metadata.resp_body`,
+  but it's not ergonomic to pattern-match on. This module enriches the error's
+  metadata with a `weak_password_reasons` key for easy pattern matching:
+
+      {:error, %Supabase.Error{metadata: %{weak_password_reasons: [:length]}}}
+
+  ## Reasons
+
+  - `:length` — password is too short
+  - `:characters` — password lacks required character diversity
+  - `:pwned` — password was found in a known breach database
+
+  ## Examples
+
+      case Auth.sign_up(client, creds) do
+        {:error, %Supabase.Error{metadata: %{weak_password_reasons: reasons}}} ->
+          # handle weak password with reasons like [:length, :characters]
+
+        {:error, %Supabase.Error{} = err} ->
+          # handle other errors
+      end
+
+  Or using the helper functions:
+
+      case Auth.sign_up(client, creds) do
+        {:error, err} when is_struct(err, Supabase.Error) ->
+          if WeakPasswordError.weak_password?(err) do
+            reasons = WeakPasswordError.reasons(err)
+            # ...
+          end
+      end
+  """
+
+  @type reason :: :length | :characters | :pwned
+
+  @known_reasons ~w[length characters pwned]
+
+  @doc """
+  Enriches a `Supabase.Error` with weak password data if present in the response body.
+
+  Parses `metadata.resp_body` for weak password information and adds
+  `weak_password_reasons` to the metadata map. Returns the error unchanged
+  if it's not a weak password error.
+  """
+  @spec maybe_enrich(Supabase.Error.t()) :: Supabase.Error.t()
+  def maybe_enrich(%Supabase.Error{metadata: %{resp_body: resp_body}} = error) when is_map(resp_body) do
+    cond do
+      match?(%{"weak_password" => %{"reasons" => [_ | _]}}, resp_body) ->
+        enrich(error, resp_body)
+
+      resp_body["error_code"] == "weak_password" ->
+        enrich(error, resp_body)
+
+      true ->
+        error
+    end
+  end
+
+  def maybe_enrich(%Supabase.Error{} = error), do: error
+
+  @doc """
+  Returns `true` if the error contains weak password reasons in its metadata.
+  """
+  @spec weak_password?(Supabase.Error.t()) :: boolean()
+  def weak_password?(%Supabase.Error{metadata: %{weak_password_reasons: [_ | _]}}), do: true
+  def weak_password?(%Supabase.Error{}), do: false
+
+  @doc """
+  Extracts the weak password reasons from an enriched error.
+
+  Returns an empty list if the error is not a weak password error.
+  """
+  @spec reasons(Supabase.Error.t()) :: [reason()]
+  def reasons(%Supabase.Error{metadata: %{weak_password_reasons: reasons}}), do: reasons
+  def reasons(%Supabase.Error{}), do: []
+
+  defp enrich(%Supabase.Error{} = error, resp_body) do
+    reasons =
+      resp_body
+      |> get_in(["weak_password", "reasons"])
+      |> List.wrap()
+      |> Enum.filter(&(&1 in @known_reasons))
+      |> Enum.map(&String.to_existing_atom/1)
+
+    message = resp_body["msg"] || resp_body["message"] || error.message
+
+    metadata = Map.put(error.metadata, :weak_password_reasons, reasons)
+    %{error | message: message, metadata: metadata}
+  end
+end

--- a/test/supabase/auth/weak_password_error_test.exs
+++ b/test/supabase/auth/weak_password_error_test.exs
@@ -1,0 +1,163 @@
+defmodule Supabase.Auth.WeakPasswordErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Supabase.Auth.WeakPasswordError
+
+  describe "maybe_enrich/1" do
+    test "enriches error when resp_body has weak_password reasons" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        message: "Unprocessable Entity",
+        service: :auth,
+        metadata: %{
+          resp_body: %{
+            "error_code" => "weak_password",
+            "msg" => "Password too short",
+            "weak_password" => %{"reasons" => ["length"]}
+          }
+        }
+      }
+
+      enriched = WeakPasswordError.maybe_enrich(error)
+
+      assert %Supabase.Error{} = enriched
+      assert enriched.metadata.weak_password_reasons == [:length]
+      assert enriched.message == "Password too short"
+    end
+
+    test "enriches error with multiple reasons" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        message: "Unprocessable Entity",
+        service: :auth,
+        metadata: %{
+          resp_body: %{
+            "error_code" => "weak_password",
+            "msg" => "Password is not strong enough",
+            "weak_password" => %{"reasons" => ["length", "characters", "pwned"]}
+          }
+        }
+      }
+
+      enriched = WeakPasswordError.maybe_enrich(error)
+
+      assert enriched.metadata.weak_password_reasons == [:length, :characters, :pwned]
+    end
+
+    test "passes through non-weak-password errors unchanged" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        message: "Validation failed",
+        service: :auth,
+        metadata: %{
+          resp_body: %{"error_code" => "validation_failed", "msg" => "Invalid email"}
+        }
+      }
+
+      assert WeakPasswordError.maybe_enrich(error) == error
+    end
+
+    test "passes through errors without resp_body" do
+      error = %Supabase.Error{
+        code: :unexpected,
+        message: "Unexpected",
+        service: :auth,
+        metadata: %{}
+      }
+
+      assert WeakPasswordError.maybe_enrich(error) == error
+    end
+
+    test "passes through errors with non-map resp_body" do
+      error = %Supabase.Error{
+        code: :unexpected,
+        message: "Unexpected",
+        service: :auth,
+        metadata: %{resp_body: "some string"}
+      }
+
+      assert WeakPasswordError.maybe_enrich(error) == error
+    end
+
+    test "enriches when error_code is weak_password but reasons are empty" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        message: "Unprocessable Entity",
+        service: :auth,
+        metadata: %{
+          resp_body: %{
+            "error_code" => "weak_password",
+            "msg" => "Weak password"
+          }
+        }
+      }
+
+      enriched = WeakPasswordError.maybe_enrich(error)
+
+      assert enriched.metadata.weak_password_reasons == []
+      assert enriched.message == "Weak password"
+    end
+
+    test "filters unknown reasons" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        message: "Unprocessable Entity",
+        service: :auth,
+        metadata: %{
+          resp_body: %{
+            "error_code" => "weak_password",
+            "msg" => "Weak password",
+            "weak_password" => %{"reasons" => ["length", "unknown_reason"]}
+          }
+        }
+      }
+
+      enriched = WeakPasswordError.maybe_enrich(error)
+
+      assert enriched.metadata.weak_password_reasons == [:length]
+    end
+  end
+
+  describe "weak_password?/1" do
+    test "returns true for enriched weak password errors" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        metadata: %{weak_password_reasons: [:length]}
+      }
+
+      assert WeakPasswordError.weak_password?(error)
+    end
+
+    test "returns false for regular errors" do
+      error = %Supabase.Error{code: :unprocessable_entity, metadata: %{}}
+
+      refute WeakPasswordError.weak_password?(error)
+    end
+
+    test "returns false for empty reasons list" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        metadata: %{weak_password_reasons: []}
+      }
+
+      refute WeakPasswordError.weak_password?(error)
+    end
+  end
+
+  describe "reasons/1" do
+    test "extracts reasons from enriched error" do
+      error = %Supabase.Error{
+        code: :unprocessable_entity,
+        metadata: %{weak_password_reasons: [:length, :characters]}
+      }
+
+      assert WeakPasswordError.reasons(error) == [:length, :characters]
+    end
+
+    test "returns empty list for non-weak-password errors" do
+      error = %Supabase.Error{code: :unprocessable_entity, metadata: %{}}
+
+      assert WeakPasswordError.reasons(error) == []
+    end
+  end
+end

--- a/test/supabase/auth_test.exs
+++ b/test/supabase/auth_test.exs
@@ -8,6 +8,7 @@ defmodule Supabase.AuthTest do
   import Supabase.Auth.ServerSettingsFixture
   import Supabase.Auth.SessionFixture
   import Supabase.Auth.UserFixture
+  import Supabase.Auth.WeakPasswordFixture
 
   alias Supabase.Auth
   alias Supabase.Auth.Schemas.ServerHealth
@@ -726,6 +727,59 @@ defmodule Supabase.AuthTest do
 
       assert {:error, %Supabase.Error{} = error} = Auth.sign_up(client, data)
       assert error.service == :auth
+    end
+  end
+
+  describe "sign_up/2 with weak password" do
+    test "enriches error with weak password reasons", %{client: client} do
+      data = %{
+        email: "another@example.com",
+        password: "123",
+        phone: "+5522123456789",
+        options: %{captcha_token: "123", email_redirect_to: "http://localhost:3000"}
+      }
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        body = weak_password_error_json(reasons: ["length"])
+        {:ok, %Finch.Response{status: 422, body: body, headers: []}}
+      end)
+
+      assert {:error, %Supabase.Error{} = error} = Auth.sign_up(client, data)
+      assert error.metadata.weak_password_reasons == [:length]
+      assert error.message == "Password should be at least 6 characters."
+    end
+
+    test "enriches error with multiple weak password reasons", %{client: client} do
+      data = %{
+        email: "another@example.com",
+        password: "aaa",
+        phone: "+5522123456789",
+        options: %{captcha_token: "123", email_redirect_to: "http://localhost:3000"}
+      }
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        body = weak_password_error_json(reasons: ["length", "characters"])
+        {:ok, %Finch.Response{status: 422, body: body, headers: []}}
+      end)
+
+      assert {:error, %Supabase.Error{} = error} = Auth.sign_up(client, data)
+      assert error.metadata.weak_password_reasons == [:length, :characters]
+    end
+
+    test "does not enrich non-weak-password errors", %{client: client} do
+      data = %{
+        email: "another@example.com",
+        password: "123",
+        phone: "+5522123456789",
+        options: %{captcha_token: "123", email_redirect_to: "http://localhost:3000"}
+      }
+
+      expect(@mock, :request, fn %Request{}, _opts ->
+        {:ok, %Finch.Response{status: 422, body: "{}", headers: []}}
+      end)
+
+      assert {:error, %Supabase.Error{} = error} = Auth.sign_up(client, data)
+      refute Map.has_key?(error.metadata, :weak_password_reasons)
     end
   end
 

--- a/test/support/fixtures/weak_password_fixture.ex
+++ b/test/support/fixtures/weak_password_fixture.ex
@@ -1,0 +1,20 @@
+defmodule Supabase.Auth.WeakPasswordFixture do
+  @moduledoc """
+  Fixtures for weak password error responses from GoTrue.
+  """
+
+  def weak_password_resp_body(opts \\ []) do
+    reasons = Keyword.get(opts, :reasons, ["length"])
+    message = Keyword.get(opts, :message, "Password should be at least 6 characters.")
+
+    %{
+      "error_code" => "weak_password",
+      "msg" => message,
+      "weak_password" => %{"reasons" => reasons}
+    }
+  end
+
+  def weak_password_error_json(opts \\ []) do
+    opts |> weak_password_resp_body() |> Supabase.encode_json()
+  end
+end


### PR DESCRIPTION
## Problem

When GoTrue returns a weak password error (e.g. on sign up or user update), the structured `weak_password` data is buried inside `metadata.resp_body`, making it hard to pattern-match on.

Closes #60

## Solution

Added a `Supabase.Auth.WeakPasswordError` module that enriches `Supabase.Error` with a `weak_password_reasons` metadata key (`:length`, `:characters`, `:pwned`). Both `sign_up/2` and `update_user/3` now automatically enrich    weak password errors before returning them.

## Rationale

Parsing the raw response body for weak password info is repetitive and error-prone for consumers. By enriching the error at the boundary, users can simply match on `%Supabase.Error{metadata: %{weak_password_reasons: reasons}}` or use the provided `weak_password?/1` and `reasons/1` helpers.
